### PR TITLE
(MAINT) Add module workflows

### DIFF
--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -1,0 +1,124 @@
+# This is a generic workflow for Puppet module CI operations.
+name: "ci"
+
+on:
+  workflow_call:
+
+jobs:
+  setup_matrix:
+    name: "Setup Test Matrix"
+    runs-on: "ubuntu-latest"
+    outputs:
+      spec_matrix: ${{ steps.get-matrix.outputs.spec_matrix }}
+      acceptance_matrix: ${{ steps.get-matrix.outputs.matrix }}
+
+    steps:
+
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+
+      - name: "Setup ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "2.7"
+          bundler-cache: true
+
+      - name: "Bundle environment"
+        run: |
+          echo ::group::bundler environment
+          bundle env
+          echo ::endgroup::
+
+      - name: Setup Spec Test Matrix
+        id: get-matrix
+        run: |
+          bundle exec matrix_from_metadata_v2
+
+  spec:
+    name: "Spec tests (Puppet: ${{matrix.puppet_version}}, Ruby Ver: ${{matrix.ruby_version}})"
+    needs: "setup_matrix"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson( needs.setup_matrix.outputs.spec_matrix ) }}
+
+    env:
+      PUPPET_GEM_VERSION: ${{ matrix.puppet_version }}
+      FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main'  # why is this set?
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+
+      - name: "Setup ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: ${{matrix.ruby_version}}
+          bundler-cache: true
+
+      - name: "Bundle environment"
+        run: |
+          echo ::group::bundler environment
+          bundle env
+          echo ::endgroup::
+
+      - name: "Run Static & Syntax Tests"
+        run: |
+          bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
+
+      - name: "Run tests"
+        run: |
+          bundle exec rake parallel_spec
+
+  acceptance:
+    name: "Acceptance tests (${{matrix.platforms.label}}, ${{matrix.collection}}"
+    needs: "spec"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson( needs.setup_matrix.outputs.acceptance_matrix ) }}
+
+    steps:
+
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+
+      - name: "Setup ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "2.7"
+          bundler-cache: true
+
+      - name: "Bundle environment"
+        run: |
+          echo ::group::bundler environment
+          bundle env
+          echo ::endgroup::
+
+      - name: "Provision environment"
+        run: |
+          bundle exec rake 'litmus:provision[${{matrix.platforms.provider}},${{ matrix.platforms.image }}]'
+
+          # Redact password
+          FILE='spec/fixtures/litmus_inventory.yaml'
+          sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
+
+      - name: "Install"
+        run: |
+          bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
+
+      - name: "Install module"
+        run: |
+          bundle exec rake 'litmus:install_module'
+
+      - name: "Run acceptance tests"
+        run: |
+          bundle exec rake 'litmus:acceptance:parallel'
+
+      - name: "Remove test environment"
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          if [[ -f spec/fixtures/litmus_inventory.yaml ]]; then
+            bundle exec rake 'litmus:tear_down'
+          fi

--- a/.github/workflows/module_release.yml
+++ b/.github/workflows/module_release.yml
@@ -1,0 +1,41 @@
+# This is a generic workflow for releasing a Puppet module.
+# It requires that the caller sets `secrets: inherit` to ensure
+# that secrets are visible from steps in this workflow.
+name: "Release"
+
+on:
+  workflow_call:
+
+jobs:
+  release:
+    name: "Release"
+    runs-on: "ubuntu-latest"
+    steps:
+
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+        with:
+          ref: "${{ github.ref }}"
+          clean: true
+          fetch-depth: 0
+
+      - name: "Get version"
+        id: "get_version"
+        run: |
+          echo "::set-output name=version::$(jq --raw-output .version metadata.json)"
+
+      - name: "PDK build"
+        uses: "docker://puppet/pdk:nightly"
+        with:
+          args: "build"
+
+      - name: "Create release"
+        run: |
+          gh release create v${{ steps.get_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Publish module"
+        uses: "docker://puppet/pdk:nightly"
+        with:
+          args: 'release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force'

--- a/.github/workflows/module_release_prep.yml
+++ b/.github/workflows/module_release_prep.yml
@@ -1,0 +1,63 @@
+# This is a generic workflow for creating a release prep
+# pr for a puppet module.
+# It requires that the caller sets `secrets: inherit` to ensure
+# that secrets are visible from steps in this workflow.
+name: "Release prep"
+
+on:
+  workflow_call:
+
+jobs:
+  release_prep:
+    name: "Release prep"
+    runs-on: "ubuntu-20.04"
+
+    steps:
+
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 0
+
+      - name: "PDK release prep"
+        uses: "docker://puppet/iac_release:ci"
+        with:
+          args: 'release prep --force'
+        env:
+          CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Get version"
+        id: "get_version"
+        run: |
+          echo "::set-output name=version::$(jq --raw-output .version metadata.json)"
+
+      - name: "Check if a release is necessary"
+        id: "check"
+        run: |
+          git diff --quiet CHANGELOG.md && echo "::set-output name=release::false" || echo "::set-output name=release::true"
+
+      - name: "Commit changes"
+        if: ${{ steps.check.outputs.release == 'true' }}
+        run: |
+          git config --local user.email "${{ github.repository_owner }}@users.noreply.github.com"
+          git config --local user.name "GitHub Actions"
+          git add .
+          git commit -m "Release prep v${{ steps.get_version.outputs.version }}"
+
+      - name: "Create pull Request"
+        uses: "peter-evans/create-pull-request@v4"
+        if: ${{ steps.check.outputs.release == 'true' }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Release prep v${{ steps.get_version.outputs.version }}"
+          branch: "release-prep"
+          delete-branch: true
+          title: "Release prep v${{ steps.get_version.outputs.version }}"
+          base: "main"
+          body: |
+            Automated release-prep through [pdk-templates](https://github.com/puppetlabs/pdk-templates/blob/main/moduleroot/.github/workflows/auto_release.yml.erb) from commit ${{ github.sha }}.
+            Please verify before merging:
+            - [ ] last [nightly](https://github.com/${{ github.repository }}/actions/workflows/nightly.yml) run is green
+            - [ ] [Changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) is readable and has no unlabeled pull requests
+            - [ ] Ensure the [changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) version and [metadata](https://github.com/${{ github.repository }}/blob/release-prep/metadata.json) version match
+          labels: "maintenance"


### PR DESCRIPTION
This PR adds reusable worflows for Puppet modules.

They could potentially replace the current set of workflows that are deployed via the pdk-templates.

The benefit of reusable workflows is that they can be easily updated from a single source.