### PR TITLE
(MAINT) Add yamllint workflow

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -1,7 +1,7 @@
 name: "ci"
 
 on:
- workflow_call:
+  workflow_call:
     inputs:
       with_acceptance:
         description: "Run an acceptance test job."
@@ -32,7 +32,7 @@ jobs:
           echo ::endgroup::
 
       - name: "rubocop"
-        run : |
+        run: |
           bundle exec rubocop
 
       - name: "spec"

--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -5,12 +5,12 @@ name: "Release"
 
 on:
   workflow_call:
-   inputs:
-    target:
-      description: "The target for the release. This can be a commit sha or a branch."
-      required: false
-      default: "main"
-      type: "string"
+    inputs:
+      target:
+        description: "The target for the release. This can be a commit sha or a branch."
+        required: false
+        default: "main"
+        type: "string"
 
 jobs:
   release:

--- a/.github/workflows/gem_release_prep.yml
+++ b/.github/workflows/gem_release_prep.yml
@@ -6,12 +6,12 @@ name: "Release Prep"
 
 on:
   workflow_call:
-   inputs:
-    target:
-      description: "The target for the release. This can be a commit sha or a branch."
-      required: false
-      default: "main"
-      type: "string"
+    inputs:
+      target:
+        description: "The target for the release. This can be a commit sha or a branch."
+        required: false
+        default: "main"
+        type: "string"
 
 jobs:
   release_prep:
@@ -71,4 +71,3 @@ jobs:
           body: |
             Automated release-prep through from commit ${{ github.sha }}.
           labels: "maintenance"
-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: "lint"
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  lint:
+    runs-on: "ubuntu-latest"
+    steps:
+
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+
+      - name: "Run yaml-lint"
+        uses: "ibiqlik/action-yamllint@v3"
+        with:
+          file_or_dir: ".github/"
+          config_file: ".yamllint"

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+---
+extends: default
+
+rules:
+  document-start: disable
+  truthy: disable
+  line-length: disable
+


### PR DESCRIPTION
Prior to this commit it was not possible validate workflow files on push/pr. This generally would lead to inconsistent styles/formatting.

This change adds a lint workflow that uses yamllint that will be executed on push to main and PR to main.