### PR TITLE
(MAINT) Update CI workflow input

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -7,8 +7,8 @@ on:
       with_acceptance:
         description: "Run an acceptance test job."
         required: false
-        default: "true"
-        type: "string"
+        default: true
+        type: "boolean"
 
 jobs:
   spec:
@@ -41,7 +41,7 @@ jobs:
           bundle exec rake spec
 
   acceptance:
-    if: github.event.inputs.with_acceptance == 'true'
+    if: "${{ inputs.with_acceptance == true }}"
     name: "acceptance"
     runs-on: "ubuntu-latest"
     needs: "spec"
@@ -55,7 +55,7 @@ jobs:
         uses: "actions/checkout@v3"
 
       - name: "setup ruby"
-        uses: ruby/setup-ruby@v1
+        uses: "ruby/setup-ruby@v1"
         with:
           ruby-version: "2.7"
           bundler-cache: true


### PR DESCRIPTION
Prior to this PR acceptance tests were not triggering when the value of `with_acceptance` was set to `true`. This is true for the default value and user provided values.

It turns out that this is because of context differences between events. Namely `workflow_call` and `workflow_dispatch`.

With `workflow_dispatch` events, inputs come from
`github.event.inputs.<input_name>' and boolean values are treated as strings.

With `workflow_call` events, inputs come from `inputs.<input_name>` and boolean values are treated as booleans.

I would still be stuck in a hole if it wasn't for this blog:

https://medium.com/@sohail.ra5/github-actions-passing-boolean-input-variables-to-reusable-workflow-call-42d39bf7342e