### PR TITLE
(MAINT) Add mend scanning workflow

### DIFF
--- a/.github/workflows/mend_ruby.yml
+++ b/.github/workflows/mend_ruby.yml
@@ -1,0 +1,43 @@
+# This is a generic workfloww that can be used to scan
+# content-and-tooling projects for vulnerabilities.
+name: mend
+
+on:
+  workflow_call:
+
+jobs:
+
+  mend:
+    runs-on: "ubuntu-latest"
+
+    steps:
+
+      - name: "checkout"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 1
+
+      - name: "setup ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: 2.7
+
+      - name: "bundle lock"
+        run: bundle lock
+
+      - uses: "actions/setup-java@v3"
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: "download"
+        run: curl -o wss-unified-agent.jar https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar
+
+      - name: "scan"
+        run: java -jar wss-unified-agent.jar
+        env:
+          WS_APIKEY: ${{ secrets.MEND_API_KEY }}
+          WS_WSS_URL: https://saas-eu.whitesourcesoftware.com/agent
+          WS_USERKEY: ${{ secrets.MEND_TOKEN }}
+          WS_PRODUCTNAME: "content-and-tooling"
+          WS_PROJECTNAME: ${{  github.event.repository.name }}


### PR DESCRIPTION
This commit adds a new workflow that will scan the current repository for vulnerabilities and submit them to Puppets mend account.