### PR TITLE
(MAINT) - update pdk release images

### DIFF
--- a/.github/workflows/module_release.yml
+++ b/.github/workflows/module_release.yml
@@ -27,7 +27,7 @@ jobs:
           echo "::set-output name=version::$(jq --raw-output .version metadata.json)"
 
       - name: "PDK build"
-        uses: "docker://puppet/pdk:nightly"
+        uses: "docker://puppet/pdk:2.6.1.0"
         with:
           args: "build"
 
@@ -38,6 +38,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Publish module"
-        uses: "docker://puppet/pdk:nightly"
+        uses: "docker://puppet/pdk:2.6.1.0"
         with:
           args: 'release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force'

--- a/.github/workflows/module_release_prep.yml
+++ b/.github/workflows/module_release_prep.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: "PDK release prep"
-        uses: "docker://puppet/iac_release:ci"
+        uses: "docker://puppet/pdk:2.6.1.0"
         with:
           args: 'release prep --force'
         env:


### PR DESCRIPTION
This PR updates the pdk docker image used in both module_release_prep.yml and module_release.yml from puppet/pdk:nightly to puppet/pdk:2.6.1.0 (stable).