### PR TITLE
(MAINT) Set condition to only run for puppetlabs

### DIFF
--- a/.github/workflows/mend_ruby.yml
+++ b/.github/workflows/mend_ruby.yml
@@ -9,6 +9,7 @@ jobs:
 
   mend:
     runs-on: "ubuntu-latest"
+    if: github.repository_owner == 'puppetlabs'
 
     steps:
 


### PR DESCRIPTION
Prior to this commit all submitted PRs kicked off a mend scan, however only members of the puppetlabs org have access to the credentials for the scanner to complete. 

This commit adds a condition so that the mend scanner only runs on PRs that have an author with access to the mend credentials.

This PR was tested downstream in the following [PR](https://github.com/puppetlabs/puppetlabs-motd/pull/467/files) with negating the puppetlabs condition and I have confirmed that the workflow is skipped as expected.