### PR TITLE
(maint) - Update gem_release_prep.yml

### DIFF
--- a/.github/workflows/gem_release_prep.yml
+++ b/.github/workflows/gem_release_prep.yml
@@ -43,12 +43,10 @@ jobs:
           bundle env
           echo ::endgroup::
 
-      - name: "Get version"
-        id: "get_version"
+      - name: "Update Version"
         run: |
           current_version=$(ruby -e "require 'rubygems'; puts Gem::Specification::load(Dir.glob('*.gemspec').first).version.to_s")
-          gem_name=$(ruby -e "require 'rubygems'; puts Gem::Specification::load(Dir.glob('*.gemspec').first).name.to_s")
-          sed -i "s/$current_version/${{ github.event.inputs.version }}/g" ./lib/$gem_name/version.rb
+          sed -i "s/$current_version/${{ github.event.inputs.version }}/g" $(find . -path './lib/**' -name 'version.rb' -not -path "vendor/*")
 
       - name: "Generate changelog"
         run: |


### PR DESCRIPTION
Prior to this PR, the gem release prep workflow required the verion.rb file to be in ./lib/$gem_name/version.rb. This was determined to not be suitable, as not all gems followed this folder structure.

This PR introduces a better method, that will work for all of the gems that will use this workflow. As long as the version.rb file lives as a file or within a subdirectory of the './lib/' directory, the workflow will update the version.rb file.