### PR TITLE
(MAINT) Remove extra word in PR description

### DIFF
--- a/.github/workflows/gem_release_prep.yml
+++ b/.github/workflows/gem_release_prep.yml
@@ -73,5 +73,5 @@ jobs:
           title: "Release prep v${{ github.event.inputs.version }}"
           base: "main"
           body: |
-            Automated release-prep through from commit ${{ github.sha }}.
+            Automated release-prep from commit ${{ github.sha }}.
           labels: "maintenance"


### PR DESCRIPTION
Prior to this commit the release prep commit message contained "through". I think this had been left in by mistake when copying the original description across.

This commit removes it.