### PR TITLE
Maint update ci.yml

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -14,11 +14,16 @@ on:
         required: false
         default: "~> 7.0"
         type: "string"
+      runs_on:
+        description: "The operating system used for the runner."
+        required: false
+        default: "ubuntu-latest"
+        type: "string"
 
 jobs:
   spec:
     name: "spec"
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ inputs.runs_on }}
 
     steps:
 


### PR DESCRIPTION
This PR adds an input for "runs-on" to the gem ci workflow, so runner OS can be specified.
Defaults to "ubuntu-latest"