### PR TITLE
Maint update ci.yml

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -14,11 +14,21 @@ on:
         required: false
         default: "~> 7.0"
         type: "string"
+      rake_task:
+        description: "The name of the rake task that executes tests"
+        required: false
+        default: "spec"
+        type: "string"
+      runs_on:
+        description: "The operating system used for the runner."
+        required: false
+        default: "ubuntu-latest"
+        type: "string"
 
 jobs:
   spec:
     name: "spec"
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ inputs.runs_on }}
 
     steps:
 
@@ -49,4 +59,4 @@ jobs:
 
       - name: "spec"
         run: |
-          bundle exec rake spec
+          bundle exec rake ${{ inputs.rake_task }}

--- a/.github/workflows/gem_release_prep.yml
+++ b/.github/workflows/gem_release_prep.yml
@@ -43,12 +43,10 @@ jobs:
           bundle env
           echo ::endgroup::
 
-      - name: "Get version"
-        id: "get_version"
+      - name: "Update Version"
         run: |
           current_version=$(ruby -e "require 'rubygems'; puts Gem::Specification::load(Dir.glob('*.gemspec').first).version.to_s")
-          gem_name=$(ruby -e "require 'rubygems'; puts Gem::Specification::load(Dir.glob('*.gemspec').first).name.to_s")
-          sed -i "s/$current_version/${{ github.event.inputs.version }}/g" ./lib/$gem_name/version.rb
+          sed -i "s/$current_version/${{ github.event.inputs.version }}/g" $(find . -path './lib/**' -name 'version.rb' -not -path "vendor/*")
 
       - name: "Generate changelog"
         run: |
@@ -75,5 +73,5 @@ jobs:
           title: "Release prep v${{ github.event.inputs.version }}"
           base: "main"
           body: |
-            Automated release-prep through from commit ${{ github.sha }}.
+            Automated release-prep from commit ${{ github.sha }}.
           labels: "maintenance"


### PR DESCRIPTION
This PR introduces a "rake_task" input to gem_ci.yml.
Allows the injection of a custom rake task other than spec to execute tests, which is required for repos like https://github.com/puppetlabs/puppet-editor-services.
Defaults to "spec" if not specified.