### PR TITLE
(maint) - add rake_task input to gem_ci.yml

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -14,6 +14,11 @@ on:
         required: false
         default: "~> 7.0"
         type: "string"
+      rake_task:
+        description: "The name of the rake task that executes tests"
+        required: false
+        default: "spec"
+        type: "string"
       runs_on:
         description: "The operating system used for the runner."
         required: false
@@ -54,4 +59,4 @@ jobs:
 
       - name: "spec"
         run: |
-          bundle exec rake spec
+          bundle exec rake ${{ inputs.rake_task }}


### PR DESCRIPTION
This PR introduces a "rake_task" input to gem_ci.yml.
Allows the injection of a custom rake task other than spec to execute tests, which is required for repos like https://github.com/puppetlabs/puppet-editor-services.
Defaults to "spec" if not specified.