### PR TITLE
(Maint) - add runs on input

### DIFF
--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -3,12 +3,18 @@ name: "Module Acceptance"
 
 on:
   workflow_call:
+    inputs:
+        runs_on:
+          description: "The operating system used for the runner."
+          required: false
+          default: "ubuntu-latest"
+          type: "string"
 
 jobs:
 
   setup_matrix:
     name: "Setup Test Matrix"
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ inputs.runs_on }}
     outputs:
       acceptance_matrix: ${{ steps.get-matrix.outputs.matrix }}
 
@@ -37,7 +43,7 @@ jobs:
   acceptance:
     name: "Acceptance tests (${{matrix.platforms.label}}, ${{matrix.collection}}"
     needs: "setup_matrix"
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ inputs.runs_on }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson( needs.setup_matrix.outputs.acceptance_matrix ) }}

--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -4,11 +4,11 @@ name: "Module Acceptance"
 on:
   workflow_call:
     inputs:
-        runs_on:
-          description: "The operating system used for the runner."
-          required: false
-          default: "ubuntu-latest"
-          type: "string"
+      runs_on:
+        description: "The operating system used for the runner."
+        required: false
+        default: "ubuntu-latest"
+        type: "string"
 
 jobs:
 
@@ -41,7 +41,7 @@ jobs:
           bundle exec matrix_from_metadata_v2
 
   acceptance:
-    name: "Acceptance tests (${{matrix.platforms.label}}, ${{matrix.collection}}"
+    name: "Acceptance tests (${{matrix.platforms.label}}, ${{matrix.collection}})"
     needs: "setup_matrix"
     runs-on: ${{ inputs.runs_on }}
     strategy:

--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -3,12 +3,12 @@ name: "Module CI"
 
 on:
   workflow_call:
-      inputs:
-        runs_on:
-          description: "The operating system used for the runner."
-          required: false
-          default: "ubuntu-latest"
-          type: "string"
+    inputs:
+      runs_on:
+        description: "The operating system used for the runner."
+        required: false
+        default: "ubuntu-latest"
+        type: "string"
 
 jobs:
   setup_matrix:

--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -3,11 +3,17 @@ name: "Module CI"
 
 on:
   workflow_call:
+      inputs:
+        runs_on:
+          description: "The operating system used for the runner."
+          required: false
+          default: "ubuntu-latest"
+          type: "string"
 
 jobs:
   setup_matrix:
     name: "Setup Test Matrix"
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ inputs.runs_on }}
     outputs:
       spec_matrix: ${{ steps.get-matrix.outputs.spec_matrix }}
 
@@ -36,7 +42,7 @@ jobs:
   spec:
     name: "Spec tests (Puppet: ${{matrix.puppet_version}}, Ruby Ver: ${{matrix.ruby_version}})"
     needs: "setup_matrix"
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ inputs.runs_on }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson( needs.setup_matrix.outputs.spec_matrix ) }}


### PR DESCRIPTION
this pr adds a runs_on input to both module ci and acceptance workflows so that the github runner OS can be specified.