### PR TITLE
(CONT-404) Address deprecation warnings

### DIFF
--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: "Get version"
         id: "get_version"
         run: |
-          echo "::set-output name=version::$(ruby -e "require 'rubygems'; puts Gem::Specification::load(Dir.glob('*.gemspec').first).version.to_s")"
+          echo "version=$(ruby -e "require 'rubygems'; puts Gem::Specification::load(Dir.glob('*.gemspec').first).version.to_s")" >> $GITHUB_OUTPUT
 
       - name: "Build"
         run: |

--- a/.github/workflows/module_release.yml
+++ b/.github/workflows/module_release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Get version"
         id: "get_version"
         run: |
-          echo "::set-output name=version::$(jq --raw-output .version metadata.json)"
+          echo "version=$(jq --raw-output .version metadata.json)" >> $GITHUB_OUTPUT
 
       - name: "PDK build"
         uses: "docker://puppet/pdk:2.6.1.0"

--- a/.github/workflows/module_release_prep.yml
+++ b/.github/workflows/module_release_prep.yml
@@ -29,12 +29,12 @@ jobs:
       - name: "Get version"
         id: "get_version"
         run: |
-          echo "::set-output name=version::$(jq --raw-output .version metadata.json)"
+          echo "version=$(jq --raw-output .version metadata.json)" >> $GITHUB_OUTPUT
 
       - name: "Check if a release is necessary"
         id: "check"
         run: |
-          git diff --quiet CHANGELOG.md && echo "::set-output name=release::false" || echo "::set-output name=release::true"
+          git diff --quiet CHANGELOG.md && echo "release=false" >> $GITHUB_OUTPUT || echo "release=true" >> $GITHUB_OUTPUT
 
       - name: "Commit changes"
         if: ${{ steps.check.outputs.release == 'true' }}


### PR DESCRIPTION
Prior to this commit, it was noted that several of our team modules and tools contained github commands that were deprecated. As these commands seem to be reaching their EOL, the aim of these PRs/commits is to update them to a newer syntax to avoid crashes.