### PR TITLE
(Maint) - Add module release title

### DIFF
--- a/.github/workflows/module_release.yml
+++ b/.github/workflows/module_release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: "Create release"
         run: |
-          gh release create v${{ steps.get_version.outputs.version }}
+          gh release create v${{ steps.get_version.outputs.version }} --title v${{ steps.get_version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Prior to this PR, the release title was not specified by the module_release.yml workflow and would end up defaulting to `<release_version> <merge commit>`.

This PR adds a '--title' flag to the 'gh release create' command so that a specified release title can be used.