### PR TITLE
(MAINT) Normalize Gem Versions

### DIFF
--- a/.github/workflows/gem_release_prep.yml
+++ b/.github/workflows/gem_release_prep.yml
@@ -46,7 +46,8 @@ jobs:
       - name: "Update Version"
         run: |
           current_version=$(ruby -e "require 'rubygems'; puts Gem::Specification::load(Dir.glob('*.gemspec').first).version.to_s")
-          sed -i "s/$current_version/${{ github.event.inputs.version }}/g" $(find . -path './lib/**' -name 'version.rb' -not -path "vendor/*")
+          normalized_version=$(echo ${{ github.event.inputs.version }} | sed "s/-/./g")
+          sed -i "s/$current_version/$normalized_version/g" $(find . -path './lib/**' -name 'version.rb' -not -path "vendor/*")
 
       - name: "Generate changelog"
         run: |


### PR DESCRIPTION
This PR normalizes the input version so that it only contains `.` characters.

This will avoid issues with pre-releases: https://guides.rubygems.org/patterns/#prerelease-gems