### PR TITLE
(MAINT) Move PUPPET_GEM_VERSION

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -30,6 +30,9 @@ jobs:
     name: "spec"
     runs-on: ${{ inputs.runs_on }}
 
+    env:
+      PUPPET_GEM_VERSION: ${{ inputs.puppet_gem_version }}
+
     steps:
 
       - name: "checkout"
@@ -41,8 +44,6 @@ jobs:
 
       - name: "setup ruby"
         uses: "ruby/setup-ruby@v1"
-        env:
-          PUPPET_GEM_VERSION: ${{ inputs.puppet_gem_version }}
         with:
           ruby-version: ${{ inputs.ruby_version }}
           bundler-cache: true


### PR DESCRIPTION
This PR moves the PUPPET_GEM_VERSION declaration to the step scope. 

If this is only set on the setup-ruby tasks, other apps executed by bundler will not be able to see Puppet.