### PR TITLE
(CONT-930) - Roll out gh-changelog

### DIFF
--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -48,9 +48,17 @@ jobs:
         run: |
           bundle exec rake build
 
+      - name: "Generate release notes"
+        run: |
+          export GH_HOST=github.com
+          gh extension install chelnak/gh-changelog
+          gh changelog get --latest > OUTPUT.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Create release"
         run: |
-          gh release create v${{ steps.get_version.outputs.version }} ./pkg/*.gem --title v${{ steps.get_version.outputs.version }}
+          gh release create v${{ steps.get_version.outputs.version }} ./pkg/*.gem --title v${{ steps.get_version.outputs.version }} -F OUTPUT.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/module_release.yml
+++ b/.github/workflows/module_release.yml
@@ -31,9 +31,17 @@ jobs:
         with:
           args: "build"
 
+      - name: "Generate release notes"
+        run: |
+          export GH_HOST=github.com
+          gh extension install chelnak/gh-changelog
+          gh changelog get --latest > OUTPUT.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Create release"
         run: |
-          gh release create v${{ steps.get_version.outputs.version }} --title v${{ steps.get_version.outputs.version }}
+          gh release create v${{ steps.get_version.outputs.version }} --title v${{ steps.get_version.outputs.version }} -F OUTPUT.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/module_release_prep.yml
+++ b/.github/workflows/module_release_prep.yml
@@ -6,6 +6,11 @@ name: "Module Release Prep"
 
 on:
   workflow_call:
+    inputs:
+      version:
+        description: "Module version to be released."
+        required: true
+        type: "string"
 
 jobs:
   release_prep:
@@ -19,12 +24,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "PDK release prep"
-        uses: "docker://puppet/pdk:nightly"
-        with:
-          args: 'release prep --force'
+      - name: "Generate changelog"
+        run: |
+          export GH_HOST=github.com
+          gh extension install chelnak/gh-changelog
+          gh changelog new --next-version v${{ github.event.inputs.version }}
         env:
-          CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Update metadata.json"
+        run: |
+          current_version=$(jq --raw-output .version metadata.json)
+          # Update version in metadata.json, only matching first occurrence
+          sed -i "0,/$current_version/s//${{ github.event.inputs.version }}/" $(find . -name 'metadata.json')
 
       - name: "Get version"
         id: "get_version"


### PR DESCRIPTION
This PR:

- Replaces pdk release prep with gh-changelog
- Generates release notes using gh-changelog `get` which can then be viewed on github

It's worth mentioning that for the time being there is no autoversioning, so modules will need to have a manual version value passed to the workflow run. (similar to the process already used for tooling)