### PR TITLE
(CONT-1129) - Overriding default time for acceptace runs

### DIFF
--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -55,6 +55,7 @@ jobs:
     name: "Acceptance tests (${{matrix.platforms.label}}, ${{matrix.collection}})"
     needs: "setup_matrix"
     runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix: ${{ fromJson( needs.setup_matrix.outputs.acceptance_matrix ) }}


### PR DESCRIPTION
### Problem

We have seen that many Nightly and CI actions runs for 6 hours (default timeout of GitHub actions) and it aborted but the provision server terminated in 2 hours from the provision but still GitHub action keep running.

### Change

Overriding default timeout of action and set to 3 hours as haven't observed any job taking more then 2 hours so updating with 3 hour keeping 1 hour buffer.

### Benefit
Overriding default time will help us to avoid running jobs for default timeout as well as it will also save cost.