### PR TITLE
Maint add target input

### DIFF
--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: "Checkout"
         uses: "actions/checkout@v3"
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
@@ -59,6 +61,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"


### PR DESCRIPTION
## Summary
This does not alter the default behaviour of the workflows, just means that workflows triggered on the `pull_request_event` trigger can also check out the PR branch and not just main.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
