### PR TITLE
(CAT-1311) Separate mend reporting for modules and tools

### DIFF
--- a/.github/workflows/tooling_mend_ruby.yml
+++ b/.github/workflows/tooling_mend_ruby.yml
@@ -1,0 +1,44 @@
+# This is a generic workfloww that can be used to scan
+# content-and-tooling projects for vulnerabilities.
+name: mend
+
+on:
+  workflow_call:
+
+jobs:
+
+  mend:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: "ubuntu-latest"
+
+    steps:
+
+      - name: "checkout"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 1
+
+      - name: "setup ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: 2.7
+
+      - name: "bundle lock"
+        run: bundle lock
+
+      - uses: "actions/setup-java@v3"
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: "download"
+        run: curl -o wss-unified-agent.jar https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar
+
+      - name: "scan"
+        run: java -jar wss-unified-agent.jar
+        env:
+          WS_APIKEY: ${{ secrets.MEND_API_KEY }}
+          WS_WSS_URL: https://saas-eu.whitesourcesoftware.com/agent
+          WS_USERKEY: ${{ secrets.MEND_TOKEN }}
+          WS_PRODUCTNAME: "cat-tooling"
+          WS_PROJECTNAME: ${{  github.event.repository.name }}


### PR DESCRIPTION
Prior to this commit all mend reports were shared between both tooling and supported modules. This commit seperates them out.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
