### PR TITLE
[CAT-1356] : Adding REFERENCE.md updation in module release prep

### DIFF
--- a/.github/workflows/module_release_prep.yml
+++ b/.github/workflows/module_release_prep.yml
@@ -38,6 +38,22 @@ jobs:
           # Update version in metadata.json, only matching first occurrence
           sed -i "0,/$current_version/s//${{ github.event.inputs.version }}/" $(find . -name 'metadata.json')
 
+      - name: "setup ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.2"
+          bundler-cache: "true"
+
+      - name: "bundle environment"
+        run: |
+          echo ::group::bundler environment
+          bundle env
+          echo ::endgroup::
+
+      - name: "Update REFERENCE.md"
+        run: |
+          bundle exec rake strings:generate:reference
+
       - name: "Get version"
         id: "get_version"
         run: |


### PR DESCRIPTION
## Summary
Adding REFERENCE.md updation in module release prep

## Additional Context
Currently all `REFERENCE.md`s are out of date for all the repos that currently use puppet-strings. Therefore, adding its updation in release prep.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
