### PR TITLE
(MAINT) - Debugging bundler issue with ruby 3.2

### DIFF
--- a/.github/workflows/module_release_prep.yml
+++ b/.github/workflows/module_release_prep.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           ruby-version: "3.2"
           bundler-cache: "true"
+          bundler: 2.4.22
 
       - name: "bundle environment"
         run: |


### PR DESCRIPTION
## Summary

Ruby 3.2 using old bundler which is causing generating reference with old puppet-string gem.


## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
