### PR TITLE
(bug) - Remove third party rubygems registry dependency

### DIFF
--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Create release"
+      - name: "Create GitHub release"
         run: |
           gh release create v${{ steps.get_version.outputs.version }} ./pkg/*.gem --title v${{ steps.get_version.outputs.version }} -F OUTPUT.md
         env:
@@ -68,8 +68,16 @@ jobs:
         env:
           GEM_HOST_API_KEY: '${{ secrets.GEM_HOST_API_KEY }}'
 
-      - name: Build and publish to GitHub Package
-        uses: actionshub/publish-gem-to-github@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          owner: 'puppetlabs'
+      - name: "Publish to GitHub Package"
+        run: |
+          echo "Setting up access to RubyGems"
+          mkdir -p ~/.gem
+          touch ~/.gem/credentials
+          chmod 600 ~/.gem/credentials
+
+          echo "Logging in to GitHub Package Registry"
+          echo "---" > ~/.gem/credentials
+          echo ":github: Bearer ${{ secrets.GITHUB_TOKEN }}" >> ~/.gem/credentials
+
+          echo "Pushing gem to GitHub Package Registry"
+          gem push --key "github" --host "https://rubygems.pkg.github.com/${{github.repository_owner}}" ./pkg/*.gem


### PR DESCRIPTION
Prior to this PR, we relied on actionshub/publish-gem-to-github. This action would swallow exit codes, and falsely report successful steps on non-zero exit code.

We have decided to take a manual approach, where we can essentially do this ourselves and ensure the maintenace of this step.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
