### PR TITLE
(CAT-1618) - Fix issue with concurrent coverage report uploads

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -63,6 +63,9 @@ jobs:
           bundle exec rake ${{ inputs.rake_task }}
 
       - name: Upload coverage reports to Codecov
+        # Only upload coverage reports once per CI trigger, as multiple concurrent uploads can cause issues
+        # so limit this step to only run once, with a conditional check for the latest Ruby version, on Ubuntu-latest
+        if: inputs.runs_on == 'ubuntu-latest' && inputs.ruby_version == '3.2'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
Multiple concurrent coverage report uploads will cause the steps to fail on GHA. 
We only need to upload the coverage report once per repo, so it makes sense anyway to remove these duplicate uploads.

## Additional Context
See here for example: https://github.com/puppetlabs/puppetfile-resolver/actions/runs/7530251054/job/20496211429?pr=5

Inspired by solution here https://github.com/codecov/codecov-action/issues/40, seems there is no real elegant way to do this but to limit it to the factors of your CI matrixes.

Can be seen working here - https://github.com/puppetlabs/puppetfile-resolver/actions/runs/7530785534/job/20497934824

Notice the step only executes in the job ubuntu-latest ruby 3.2

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
