### PR TITLE
(CAT-1618) - Fix issue with code coverage in nightlies

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -63,9 +63,13 @@ jobs:
           bundle exec rake ${{ inputs.rake_task }}
 
       - name: Upload coverage reports to Codecov
-        # Only upload coverage reports once per CI trigger, as multiple concurrent uploads can cause issues
+        # Only upload coverage reports once per CI.yml trigger, as multiple concurrent uploads can cause issues
         # so limit this step to only run once, with a conditional check for the latest Ruby version, on Ubuntu-latest
-        if: inputs.runs_on == 'ubuntu-latest' && inputs.ruby_version == '3.2'
+        # the check on inputs.rake_task helps to ensure this is only run when coverage rake_task has been executed
+        if: |
+          contains(inputs.rake_task, 'coverage') &&
+          inputs.runs_on == 'ubuntu-latest' &&
+          inputs.ruby_version == '3.2'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Prior to this PR, code coverage reports would attempt to upload from the nightlies despite no code coverage reports being generated. This is because we only run code coverage in the ci.yml job, and not nightly.yml.

This PR adds another conditional to the upload coverage reports to Codecov step, to ensure this step is only run when a coverage rake_task has been supplied.

## Additional Context
You can see here that this step does not execute anymore when the coverage rask_task task is not run here https://github.com/puppetlabs/puppet-modulebuilder/actions/runs/7540032930/job/20523775839?pr=68.

When the coverage rask_task is run however, it executes like normal see here https://github.com/puppetlabs/puppet-modulebuilder/actions/runs/7540019355/job/20523734764

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
