### PR TITLE
(maint) - Update checkout ref on mend pr trigger

### DIFF
--- a/.github/workflows/tooling_mend_ruby.yml
+++ b/.github/workflows/tooling_mend_ruby.yml
@@ -8,15 +8,30 @@ on:
 jobs:
 
   mend:
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: "ubuntu-latest"
 
     steps:
+      # To access the mend secrets, we now need to trigger on pull_request_target event
+      # which by default runs in the context of the main branch, so we use this to retrieve
+      # the PR object and then checkout the merge commit sha
+      - name: "Retrieve PR"
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        id: pr
+        with:
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            return pullRequest
 
       - name: "checkout"
         uses: "actions/checkout@v4"
         with:
           fetch-depth: 1
+          # If we are on a PR, checkout the merge commit sha, else checkout the main branch
+          ref: ${{ fromJSON(steps.pr.outputs.result).merge_commit_sha || 'refs/heads/main'}}
 
       - name: "setup ruby"
         uses: "ruby/setup-ruby@v1"


### PR DESCRIPTION
## Summary
We need a way to run mend scanning on PRs to our repos, but due to security you cannot access the necessary secrets on `pull_request`. Now, we will trigger our mend scans on `pull_request_target` which will have access to the necessary secrets, but by default this runs in the context of the base branch.

Now we will use the **workflow from main**, but the **code from the pr**, to enable us to run mend scanning safely on all submitted prs.

Inspired by https://dev.to/suzukishunsuke/secure-github-actions-by-pullrequesttarget-641#:~:text=To%20checkout%20the%20merged%20commit,to%20actions%2Fcheckout%20input%20ref%20.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
