### PR TITLE
Update link for module release prep

### DIFF
--- a/.github/workflows/module_release_prep.yml
+++ b/.github/workflows/module_release_prep.yml
@@ -87,7 +87,7 @@ jobs:
           title: "Release prep v${{ steps.get_version.outputs.version }}"
           base: "main"
           body: |
-            Automated release-prep through [pdk-templates](https://github.com/puppetlabs/pdk-templates/blob/main/moduleroot/.github/workflows/auto_release.yml.erb) from commit ${{ github.sha }}.
+            Automated release-prep through [pdk-templates](https://github.com/puppetlabs/pdk-templates/blob/main/moduleroot/.github/workflows/release_prep.yml.erb) from commit ${{ github.sha }}.
             Please verify before merging:
             - [ ] last [nightly](https://github.com/${{ github.repository }}/actions/workflows/nightly.yml) run is green
             - [ ] [Changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) is readable and has no unlabeled pull requests


### PR DESCRIPTION
The module release prep action was renamed in
puppetlabs/pdk-templates@c3f57b7. This commit updates the template for a module release prep to point to the new location of the action.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
