### PR TITLE
(CAT-1829) - Update to dynamic checkout ref gem_ci

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -34,9 +34,22 @@ jobs:
       PUPPET_GEM_VERSION: ${{ inputs.puppet_gem_version }}
 
     steps:
+      # If we are on a PR, checkout the PR head sha, else checkout the default branch
+      # required when trigger set to pull_request_target
+      - name: "Set the checkout ref"
+        id: set_ref
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          else
+            echo "ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: "checkout"
         uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 1
+          ref: ${{ steps.set_ref.outputs.ref }}
 
       - name: "export environment"
         run: |


### PR DESCRIPTION
This commit implements a dynamic checkout ref for the gem_ci workflow. This is because we will be updating the calling workflows to be run on the pull_request_target trigger so they can safely access secrets, so this extra checkout logic is needed in order to checkout the head branch.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
