### PR TITLE
Better forked module support

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -82,7 +82,8 @@ jobs:
         if: |
           contains(inputs.rake_task, 'coverage') &&
           inputs.runs_on == 'ubuntu-latest' &&
-          inputs.ruby_version == '3.2'
+          inputs.ruby_version == '3.2' &&
+          secrets.CODECOV_TOKEN
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -1,22 +1,21 @@
 name: Labeller
 
 on:
-  issues:
-    types:
-      - opened
-      - labeled
-      - unlabeled
-  pull_request_target:
-    types:
-      - opened
-      - labeled
-      - unlabeled
+  workflow_call:
+    inputs:
+      token:
+        type: string
 
 jobs:
   label:
+    name: ${{ github.event.action }} ${{ github.event_name }}
+    # case if the workflow is called improperly
+    if: |
+      contains(fromJson('["puppetlabs", "puppet-toy-chest"]'), github.repository_owner) &&
+      contains(fromJson('["pull_request_target", "issues"]'), github.event_name) &&
+      contains(fromJson('["opened", "reopened", "labeled", "unlabeled"]'), github.event.action)
     runs-on: ubuntu-latest
     steps:
-
       - uses: puppetlabs/community-labeller@v1.0.1
         name: Label issues or pull requests
         with:
@@ -24,4 +23,4 @@ jobs:
           label_color: '5319e7'
           org_membership: puppetlabs
           fail_if_member: 'true'
-          token: ${{ secrets.IAC_COMMUNITY_LABELER }}
+          token: ${{ inputs.token != '' && inputs.token || secrets.IAC_COMMUNITY_TOKEN }}

--- a/.github/workflows/mend_ruby.yml
+++ b/.github/workflows/mend_ruby.yml
@@ -5,13 +5,31 @@ name: mend
 on:
   workflow_call:
 
-jobs:
+env:
+  MEND_API_KEY: ${{ secrets.MEND_API_KEY }}
+  MEND_TOKEN: ${{ secrets.MEND_TOKEN }}
+  PRODUCT_NAME: ${{ vars.PRODUCT_NAME && vars.PRODUCT_NAME || 'content-and-tooling' }}
+  REQUIRE_SECRETS: MEND_API_KEY MEND_TOKEN
 
+jobs:
   mend:
     runs-on: "ubuntu-latest"
+    continue-on-error: ${{ contains(fromJson('["puppetlabs", "puppet-toy-chest"]'), github.repository_owner) == false }}
     steps:
+      - name: "check requirements"
+        run: |
+          declare -a MISSING
+          for V in ${REQUIRE_SECRETS} ; do
+            [[ -z "${!V}" ]] && MISSING+=($V)
+          done
+          if [ ${#MISSING[@]} -gt 0 ] ; then
+            echo "::warning::missing required secrets: ${MISSING[@]}"
+            exit 1
+          fi
+
       # If we are on a PR, checkout the PR head sha, else checkout the default branch
       - name: "Set the checkout ref"
+        if: success()
         id: set_ref
         run: |
           if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
@@ -21,32 +39,38 @@ jobs:
           fi
 
       - name: "checkout"
+        if: success()
         uses: "actions/checkout@v4"
         with:
           fetch-depth: 1
           ref: ${{ steps.set_ref.outputs.ref }}
 
       - name: "setup ruby"
+        if: success()
         uses: "ruby/setup-ruby@v1"
         with:
           ruby-version: 2.7
 
       - name: "bundle lock"
+        if: success()
         run: bundle lock
 
       - uses: "actions/setup-java@v4"
+        if: success()
         with:
           distribution: "temurin"
           java-version: "17"
 
       - name: "download"
+        if: success()
         run: curl -o wss-unified-agent.jar https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar
 
       - name: "scan"
+        if: success()
         run: java -jar wss-unified-agent.jar
         env:
-          WS_APIKEY: ${{ secrets.MEND_API_KEY }}
+          WS_APIKEY: ${{ env.MEND_API_KEY }}
           WS_WSS_URL: https://saas-eu.whitesourcesoftware.com/agent
-          WS_USERKEY: ${{ secrets.MEND_TOKEN }}
-          WS_PRODUCTNAME: "content-and-tooling"
-          WS_PROJECTNAME: ${{  github.event.repository.name }}
+          WS_USERKEY: ${{ env.MEND_TOKEN }}
+          WS_PRODUCTNAME: ${{ env.PRODUCT_NAME }}
+          WS_PROJECTNAME: ${{ github.event.repository.name }}

--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -14,7 +14,14 @@ on:
         required: false
         default: ''
         type: "string"
-
+      kernel_modules:
+        description: "Volume map host kernel /lib/modules into docker container"
+        default: true
+        type: boolean
+      disable_apparmor:
+        description: "Disable and stop apparmor"
+        default: false
+        type: boolean
 
 jobs:
 
@@ -68,6 +75,14 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@v4"
 
+      - name: "Disable Apparmor"
+        if: ${{ inputs.disable_apparmor }}
+        run: |
+          sudo find /etc/apparmor.d/ -maxdepth 1 -type f -exec ln -sf {} /etc/apparmor.d/disable/ \;
+          sudo apparmor_parser -R /etc/apparmor.d/disable/* || true
+          sudo systemctl disable apparmor
+          sudo systemctl stop apparmor
+
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
@@ -82,7 +97,7 @@ jobs:
 
       - name: "Provision environment"
         run: |
-          if [[ "${{matrix.platforms.provider}}" == "docker" ]]; then
+          if [[ "${{ inputs.kernel_modules }}" == "true" ]] && [[ "${{matrix.platforms.provider}}" =~ docker* ]] ; then
             DOCKER_RUN_OPTS="docker_run_opts: {'--volume': '/lib/modules/$(uname -r):/lib/modules/$(uname -r)'}"
           else
             DOCKER_RUN_OPTS=''

--- a/.github/workflows/module_release.yml
+++ b/.github/workflows/module_release.yml
@@ -10,9 +10,14 @@ jobs:
   release:
     name: "Release"
     runs-on: "ubuntu-latest"
-    if: github.repository_owner == 'puppetlabs'
 
     steps:
+      - name: "Check Requirements"
+        run: |
+          if [[ -z "${{ secrets.FORGE_API_KEY }}" ]] ; then
+            echo "::error::missing required secret: FORGE_API_KEY"
+            exit 1
+          fi
 
       - name: "Checkout"
         uses: "actions/checkout@v4"

--- a/.github/workflows/tooling_mend_ruby.yml
+++ b/.github/workflows/tooling_mend_ruby.yml
@@ -5,13 +5,31 @@ name: mend
 on:
   workflow_call:
 
-jobs:
+env:
+  MEND_API_KEY: ${{ secrets.MEND_API_KEY }}
+  MEND_TOKEN: ${{ secrets.MEND_TOKEN }}
+  PRODUCT_NAME: ${{ vars.PRODUCT_NAME && vars.PRODUCT_NAME || 'DevX' }}
+  REQUIRE_SECRETS: MEND_API_KEY MEND_TOKEN
 
+jobs:
   mend:
     runs-on: "ubuntu-latest"
+    continue-on-error: ${{ contains(fromJson('["puppetlabs", "puppet-toy-chest"]'), github.repository_owner) == false }}
     steps:
+      - name: "check requirements"
+        run: |
+          declare -a MISSING
+          for V in ${REQUIRE_SECRETS} ; do
+            [[ -z "${!V}" ]] && MISSING+=($V)
+          done
+          if [ ${#MISSING[@]} -gt 0 ] ; then
+            echo "::warning::missing required secrets: ${MISSING[@]}"
+            exit 1
+          fi
+
       # If we are on a PR, checkout the PR head sha, else checkout the default branch
       - name: "Set the checkout ref"
+        if: success()
         id: set_ref
         run: |
           if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
@@ -21,20 +39,24 @@ jobs:
           fi
 
       - name: "checkout"
+        if: success()
         uses: "actions/checkout@v4"
         with:
           fetch-depth: 1
           ref: ${{ steps.set_ref.outputs.ref }}
 
       - name: "setup ruby"
+        if: success()
         uses: "ruby/setup-ruby@v1"
         with:
           ruby-version: 2.7
 
       - name: "bundle lock"
+        if: success()
         run: bundle lock
 
       - uses: "actions/setup-java@v4"
+        if: success()
         with:
           distribution: "temurin"
           java-version: "17"
@@ -43,10 +65,11 @@ jobs:
         run: curl -o wss-unified-agent.jar https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar
 
       - name: "scan"
+        if: success()
         run: java -jar wss-unified-agent.jar
         env:
-          WS_APIKEY: ${{ secrets.MEND_API_KEY }}
+          WS_APIKEY: ${{ env.MEND_API_KEY }}
           WS_WSS_URL: https://saas-eu.whitesourcesoftware.com/agent
-          WS_USERKEY: ${{ secrets.MEND_TOKEN }}
-          WS_PRODUCTNAME: "DevX"
-          WS_PROJECTNAME: ${{  github.event.repository.name }}
+          WS_USERKEY: ${{ env.MEND_TOKEN }}
+          WS_PRODUCTNAME: ${{ env.PRODUCT_NAME }}
+          WS_PROJECTNAME: ${{ github.event.repository.name }}


### PR DESCRIPTION
Rationale, workflow jobs generate a lot of unnecessary action noise on forking a repo.
Gate what make sense, and open others up.

Adds inputs to acceptance workflow so modules (like mysql and firewall) can take advantage of these templates.