### PR TITLE
(bug) - gem_ci.yml fix Unrecognized named-value: secrets

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -32,6 +32,7 @@ jobs:
 
     env:
       PUPPET_GEM_VERSION: ${{ inputs.puppet_gem_version }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - name: "checkout"
@@ -74,7 +75,7 @@ jobs:
           contains(inputs.rake_task, 'coverage') &&
           inputs.runs_on == 'ubuntu-latest' &&
           inputs.ruby_version == '3.2' &&
-          secrets.CODECOV_TOKEN
+          env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The secrets context is not available to GHA conditionals. Update to write the secret to an ENV variable, which we can then check isn't an empty string.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Available expression contexts: github, inputs, vars, needs, strategy, matrix, steps, job, runner, env
## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
