### PR TITLE
CAT-1918 : Adding check for version from metadata.json

### DIFF
--- a/.github/workflows/module_release.yml
+++ b/.github/workflows/module_release.yml
@@ -14,6 +14,11 @@ jobs:
 
     steps:
 
+      - name: "Set up Ruby"
+        uses: "actions/setup-ruby@v1"
+        with:
+          ruby-version: "3.1"
+
       - name: "Checkout"
         uses: "actions/checkout@v4"
         with:
@@ -24,7 +29,22 @@ jobs:
       - name: "Get version"
         id: "get_version"
         run: |
-          echo "version=$(jq --raw-output .version metadata.json)" >> $GITHUB_OUTPUT
+          ruby <<-EOF >> $GITHUB_OUTPUT
+            require "json"
+            version = JSON.parse(File.read("metadata.json"))["version"]
+
+            # from https://github.com/voxpupuli/metadata-json-lint/blob/b5e68049c6be58aa63263357bb0dcad8635a6829/lib/metadata-json-lint/schema.rb#L141-L150
+            numeric = '(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)' # Major . Minor . Patch
+            pre = '(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?' # Prerelease
+            build = '(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?' # Build
+            full = numeric + pre + build
+            semver_regex = /\A#{full}\Z/
+            if version&.match?(semver_regex)
+              puts "version=#{version}"
+            else
+              raise "Version #{version} is invalid. Exiting workflow."
+            end
+          EOF
 
       - name: "PDK build"
         uses: "docker://puppet/pdk:nightly"


### PR DESCRIPTION
## Summary
This PR introduces a new check to ensure that only versions containing numerical values are considered for inclusion in the release process. The implementation involves retrieving the version information from the metadata.json file and validating it to contain only numeric characters. This enhancement aims to improve the reliability and consistency of the release workflow by preventing the inclusion of invalid or malformed version identifiers.
Also regex is considered from this reference [metadata-json-lint](https://github.com/voxpupuli/metadata-json-lint/blob/b5e68049c6be58aa63263357bb0dcad8635a6829/lib/metadata-json-lint/schema.rb#L141-L150)


## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
