### PR TITLE
Adding ruby version as an input for the gem workflows

### DIFF
--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -11,6 +11,11 @@ on:
         required: false
         default: "main"
         type: "string"
+      ruby-version:
+        description: "Ruby version to use."
+        required: false
+        default: "2.7"
+        type: "string"
 
 jobs:
   release:
@@ -30,7 +35,7 @@ jobs:
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "2.7"
+          ruby-version: ${{ github.event.inputs.ruby-version }}
           bundler-cache: "true"
 
       - name: "Bundle environment"

--- a/.github/workflows/gem_release_prep.yml
+++ b/.github/workflows/gem_release_prep.yml
@@ -16,6 +16,11 @@ on:
         description: "Version of gem to be released."
         required: true
         type: "string"
+      ruby-version:
+        description: "Ruby version to use."
+        required: false
+        default: "2.7"
+        type: "string"
 
 jobs:
   release_prep:
@@ -34,7 +39,7 @@ jobs:
       - name: "setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "2.7"
+          ruby-version: ${{ github.event.inputs.ruby-version }}
           bundler-cache: "true"
 
       - name: "bundle environment"


### PR DESCRIPTION
## Summary
Adding ruby version as an input for the gem workflows. While keeping the default as 2.7

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
