### PR TITLE
(CAT-2013) Implement shellcheck in ci workflow

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -24,6 +24,11 @@ on:
         required: false
         default: "ubuntu-latest"
         type: "string"
+      run_shellcheck:
+        description: "Run shellcheck on all bash files"
+        required: false
+        default: false
+        type: "boolean"
 
 jobs:
   spec:
@@ -39,6 +44,14 @@ jobs:
         uses: "actions/checkout@v4"
         with:
           fetch-depth: 1
+      - name: "shellcheck"
+        uses: reviewdog/action-shellcheck@v1
+        if: |
+          inputs.run_shellcheck &&
+          inputs.ruby_version == '3.2' &&
+          inputs.runs_on == 'ubuntu-latest'
+        with:
+          check_all_files_with_shebangs: "true"
 
       - name: "export environment"
         run: |


### PR DESCRIPTION
Following the implementation of a shellcheck action in a provision module workflow, we have decided it is useful enough to be implemented in our reusable gem ci workflow.

This commit adds the shellcheck action as a new job in the gem ci workflow.

Workflow tested: https://github.com/puppetlabs/pdk/pull/1402
