### PR TITLE
(CAT-2094) Add shellcheck to module_ci workflow

### DIFF
--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -14,6 +14,11 @@ on:
         required: false
         default: ''
         type: "string"
+      run_shellcheck:
+        description: "Run shellcheck on all bash files"
+        required: false
+        default: false
+        type: "boolean"
 
 
 jobs:
@@ -80,6 +85,15 @@ jobs:
           echo ::group::bundler environment
           bundle env
           echo ::endgroup::
+
+      - name: "shellcheck"
+        uses: reviewdog/action-shellcheck@v1
+        if: |
+          inputs.run_shellcheck &&
+          inputs.runs_on == 'ubuntu-latest' &&
+          matrix.ruby_version == '3.2'
+        with:
+          check_all_files_with_shebangs: "true"
 
       - name: "Run Static & Syntax Tests"
         run: |


### PR DESCRIPTION
This commit adds a shellcheck step to the module_ci workflow that can be enabled by passing the run_shellcheck variable as true when running the action.

