### PR TITLE
skip mend if PR is from a forked repo

### DIFF
--- a/.github/workflows/mend_ruby.yml
+++ b/.github/workflows/mend_ruby.yml
@@ -23,12 +23,14 @@ env:
 
 jobs:
   mend:
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: "ubuntu-latest"
     continue-on-error: ${{ contains(fromJson('["puppetlabs","puppet-toy-chest"]'), github.repository_owner) != true }}
     steps:
       - name: "check requirements"
         run: |
           declare -a MISSING
+          echo "REQUIRE2"
           for V in ${REQUIRE_SECRETS} ; do
             [[ -z "${!V}" ]] && MISSING+=($V)
           done

--- a/.github/workflows/mend_ruby.yml
+++ b/.github/workflows/mend_ruby.yml
@@ -30,7 +30,6 @@ jobs:
       - name: "check requirements"
         run: |
           declare -a MISSING
-          echo "REQUIRE2"
           for V in ${REQUIRE_SECRETS} ; do
             [[ -z "${!V}" ]] && MISSING+=($V)
           done


### PR DESCRIPTION
## Summary
Added a check to skip mend workflow if PR is raised from a forked repo

## Additional Context
When a PR was raised from a forked modules repo to main, the mend CI check is failing. This is because it requires mend token and the forked repo PR is unable to inherit the same. So to resolve the issue, we have added a step to check if the PR has been raised from a fork and if true, skip the PR pipeline.
 - [x] Root cause and the steps to reproduce. (If applicable)
  To reporduce, raise a PR to a puppetlabs module from a fork. the mend pipeline fails. The nightly pipeline still works fine.
ex: https://github.com/puppetlabs/puppetlabs-firewall/pull/1235/checks
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
