### PR TITLE
Update gem_release_prep.yml ruby. version from 2.7 to 3.1

### DIFF
--- a/.github/workflows/gem_release_prep.yml
+++ b/.github/workflows/gem_release_prep.yml
@@ -34,7 +34,7 @@ jobs:
       - name: "setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.1"
           bundler-cache: "true"
 
       - name: "bundle environment"


### PR DESCRIPTION
Prior to this commit the workflow used ruby version 2.7. As this is old and our tools are now running on Ruby 3 I have increased the version to Ruby 3.1.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
