### PR TITLE
removed deprecated actions/setup-ruby@v1 with ruby/setup-ruby@v1

### DIFF
--- a/.github/workflows/module_release.yml
+++ b/.github/workflows/module_release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: "Set up Ruby"
-        uses: "actions/setup-ruby@v1"
+        uses: "ruby/setup-ruby@v1"
         with:
           ruby-version: "3.1"
 


### PR DESCRIPTION
## Summary
removed deprecated actions/setup-ruby@v1 with ruby/setup-ruby@v1.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
