### PR TITLE
(maint) Update module_release_prep.yml to run on latest

### DIFF
--- a/.github/workflows/module_release_prep.yml
+++ b/.github/workflows/module_release_prep.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   release_prep:
     name: "Release prep"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
 
     env:
       BUNDLE_WITHOUT: development:system_tests


### PR DESCRIPTION
Prior to this commit the release prep job is running Ubuntu 20.04 which will be removed from GH Actions on the 1st April. Updating to latest to run in line with all other jobs.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
