### PR TITLE
(MAINT) Skip mend checks on community PRs

### DIFF
--- a/.github/workflows/tooling_mend_ruby.yml
+++ b/.github/workflows/tooling_mend_ruby.yml
@@ -28,6 +28,7 @@ env:
 
 jobs:
   mend:
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: "ubuntu-latest"
     continue-on-error: ${{ contains(fromJson('["puppetlabs","puppet-toy-chest"]'), github.repository_owner) != true }}
     steps:


### PR DESCRIPTION
Copied a conditional from mend_ruby.yml to skip running mend checks on PRs from forks so that we can avoid false CI failures from community PRs.
