### PR TITLE
Add PuppetCore gem source support to module_ci workflow

### DIFF
--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -30,9 +30,9 @@ on:
         default: 'forge-key'
         type: "string"
 
-# ENABLE PUPPETCORE.  The calling workflow must:  
+# ENABLE PUPPETCORE.  The calling workflow must:
 # - Set a valid PUPPET_FORGE_TOKEN secret on its repository.
-# - Set ruby_version >= 3.1 to override this workflow's default 2.7; otherwise bundle install will fail.  
+# - Set ruby_version >= 3.1 to override this workflow's default 2.7; otherwise bundle install will fail.
 env:
   PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN }}
   BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "${{ inputs.puppetcore_api_type }}:${{ secrets.PUPPET_FORGE_TOKEN }}"

--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -19,7 +19,23 @@ on:
         required: false
         default: false
         type: "boolean"
+      ruby_version:
+        description: "Ruby version to use"
+        required: false
+        default: '2.7'
+        type: "string"
+      puppetcore_api_type:
+        description: "The type of API to use for Puppet Core."
+        required: false
+        default: 'forge-key'
+        type: "string"
 
+# ENABLE PUPPETCORE.  The calling workflow must:  
+# - Set a valid PUPPET_FORGE_TOKEN secret on its repository.
+# - Set ruby_version >= 3.1 to override this workflow's default 2.7; otherwise bundle install will fail.  
+env:
+  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN }}
+  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "${{ inputs.puppetcore_api_type }}:${{ secrets.PUPPET_FORGE_TOKEN }}"
 
 jobs:
   setup_matrix:
@@ -41,7 +57,7 @@ jobs:
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "2.7"
+          ruby-version: ${{ inputs.ruby_version }}
           bundler-cache: true
 
       - name: "Bundle environment"

--- a/docs/how-to/how_to_using_module_ci_workflow_with_puppetcore_gems.md
+++ b/docs/how-to/how_to_using_module_ci_workflow_with_puppetcore_gems.md
@@ -1,0 +1,105 @@
+# How to use the module_ci workflow with puppetcore gems
+
+## Description
+
+This guide explains how to configure your repository to use the shared `module_ci.yml` workflow with PuppetCore Gems. The workflow is designed to maintain backward compatibility with existing consumers (like puppetlabs-apache and puppetlabs-ntp) while providing the capability to install and use gems from the private PuppetCore gem source.
+
+## Prerequisites
+
+- A GitHub repository that needs to use the `module_ci.yml` workflow
+- Access to repository settings to configure secrets
+- A valid `PUPPET_FORGE_TOKEN` with access to the private gem source
+
+## Configuration Requirements
+
+### Required Settings
+
+To use PuppetCore Gems with the module_ci workflow, your repository must meet these requirements:
+
+1. **Set up the PUPPET_FORGE_TOKEN secret**:
+   - Navigate to your repository on GitHub
+   - Go to Settings > Secrets and variables > Actions
+   - Add a new repository secret named `PUPPET_FORGE_TOKEN` with your valid token value
+
+2. **Configure Ruby Version**:
+   - Must specify a Ruby version >= 3.1 (required for PuppetCore Gems)
+   - The default Ruby version in module_ci.yml is 2.7 and must be overridden
+
+### Optional Settings
+
+- **PuppetCore API Type**:
+  - By default, set to 'forge-key'
+  - Can be changed to 'license-key' if required
+
+## Usage
+
+Create or update your workflow file (typically `.github/workflows/ci.yml`) to look something like:
+
+```yaml
+name: "ci"
+
+on:
+  pull_request:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  Spec:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
+    with:
+      run_shellcheck: true
+      ruby_version: '3.1' # Required for PuppetCore Gems
+    secrets: "inherit" # Required to pass PUPPET_FORGE_TOKEN
+```
+
+## How It Works
+
+When properly configured, the `module_ci.yml` workflow will:
+
+1. Inherit the `PUPPET_FORGE_TOKEN` secret from the consumer repository.
+2. Set the following `BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM` environment variable ensuring authentication against the <https://rubygems-puppetcore.puppet.com> gemsource, e.g,:
+
+   ```shell
+   BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN }}"
+   ```
+
+3. Install gems from <https://rubygems-puppetcore.puppet.com>.
+
+## Troubleshooting
+
+Common issues and their solutions:
+
+- **Bundle install fails**: Ensure Ruby version is set to at least 3.1
+- **Authentication errors**: Verify the PUPPET_FORGE_TOKEN is correctly set and has appropriate permissions
+
+## Appendix
+
+### Sample Implementation
+
+Example configuration in a consuming repository:
+
+```yaml
+name: "ci"
+
+on:
+  pull_request:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  Spec:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
+    with:
+      run_shellcheck: true
+      ruby_version: '3.1'
+      puppetcore_api_type: 'license-key'
+    secrets: "inherit"
+```
+
+### Security Considerations
+
+- Never hardcode the PUPPET_FORGE_TOKEN in your workflow files
+- Use the `secrets: "inherit"` pattern to securely pass tokens
+- Regularly rotate your tokens following security best practices


### PR DESCRIPTION
## Overview

This PR enhances the module_ci reusable workflow to support the PuppetCore private gem source. This allows modules using this workflow to access private Puppet gems when needed.

## Changes
- Added input parameters to configure:
  - Ruby version (default 2.7)
  - PuppetCore API type (default forge-key)
- Added environment configuration for PuppetCore authentication using `PUPPET_FORGE_TOKEN`.  This "secret" is then in turn used to set the `BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM` which enables authenticated access to the puppetcore gems

**ALSO** added a how to document for consumers of this re-usable module, see `docs/how-to/how_to_using_module_ci_workflow_with_puppetcore_gems.md`

## Impact

- Modules using this workflow can now access private Puppet gems when authorized
- Consuming workflows need to:
  - Set a valid PUPPET_FORGE_TOKEN secret on their repository
  - Set ruby_version >= 3.1 when using PuppetCore (bundle install will fail with Ruby 2.7)
- No breaking changes expected as all new parameters have sensible defaults and the new `module_ci.yml` has been verified with both a puppetcore enabled module <https://github.com/puppetlabs/provision> and a non-puppetcore one <https://github.com/puppetlabs/puppetlabs-apache>.  See in the comments below for proof of testing.
