### PR TITLE
Increase default ruby to 3.1 from 2.7

### DIFF
--- a/.github/workflows/gem_acceptance.yml
+++ b/.github/workflows/gem_acceptance.yml
@@ -7,7 +7,7 @@ on:
       ruby_version:
         description: "The target Ruby version."
         required: false
-        default: "2.7"
+        default: "3.1"
         type: "string"
       puppet_version:
         description: "The target Puppet version."

--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -7,7 +7,7 @@ on:
       ruby_version:
         description: "The target Ruby version."
         required: false
-        default: "2.7"
+        default: "3.1"
         type: "string"
       puppet_gem_version:
         description: "Specifies the version of the Puppet gem to be installed"

--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.1"
           bundler-cache: "true"
 
       - name: "Bundle environment"

--- a/.github/workflows/mend_ruby.yml
+++ b/.github/workflows/mend_ruby.yml
@@ -48,7 +48,7 @@ jobs:
         if: success()
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1
 
       - name: "bundle lock"
         if: success()

--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -42,7 +42,7 @@ jobs:
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: "Bundle environment"
@@ -88,7 +88,7 @@ jobs:
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: "Bundle environment"

--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -22,7 +22,7 @@ on:
       ruby_version:
         description: "Ruby version to use"
         required: false
-        default: '2.7'
+        default: '3.1'
         type: "string"
       puppetcore_api_type:
         description: "The type of API to use for Puppet Core."

--- a/.github/workflows/tooling_mend_ruby.yml
+++ b/.github/workflows/tooling_mend_ruby.yml
@@ -17,7 +17,7 @@ on:
       ruby_version:
         description: "The target Ruby version."
         required: false
-        default: "2.7"
+        default: "3.1"
         type: "string"
 
 env:


### PR DESCRIPTION
## Summary
Prior to this commit the default Ruby version in the workflows is 2.7. Increasing this to 3.1 to avoid dependency clashes.

Testing of the fix can be found here: https://github.com/puppetlabs/provision/pull/283

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
