### PR TITLE
(CAT-2286) Remove puppet 7 infrastructure

### DIFF
--- a/.github/workflows/gem_acceptance.yml
+++ b/.github/workflows/gem_acceptance.yml
@@ -12,7 +12,7 @@ on:
       puppet_version:
         description: "The target Puppet version."
         required: false
-        default: "puppet7-nightly"
+        default: "puppet8-nightly"
         type: "string"
       rake_task:
         description: "The name of the rake task that executes acceptance tests"

--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -12,7 +12,7 @@ on:
       puppet_gem_version:
         description: "Specifies the version of the Puppet gem to be installed"
         required: false
-        default: "~> 7.0"
+        default: "~> 8.0"
         type: "string"
       rake_task:
         description: "The name of the rake task that executes tests"
@@ -53,7 +53,7 @@ jobs:
         uses: reviewdog/action-shellcheck@v1
         if: |
           inputs.run_shellcheck &&
-          inputs.ruby_version == '3.2' &&
+          inputs.ruby_version == ${{ inputs.ruby_version.default }} &&
           inputs.runs_on == 'ubuntu-latest'
         with:
           check_all_files_with_shebangs: "true"
@@ -89,7 +89,7 @@ jobs:
         if: |
           contains(inputs.rake_task, 'coverage') &&
           inputs.runs_on == 'ubuntu-latest' &&
-          inputs.ruby_version == '3.2' &&
+          inputs.ruby_version == '3.1' &&
           env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -67,7 +67,7 @@ jobs:
 
     env:
       BUNDLE_WITHOUT: release_prep
-      PUPPET_GEM_VERSION: '~> 7.24'
+      PUPPET_GEM_VERSION: '~> 8.9'
       FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main'  # why is this set?
 
     steps:

--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -102,7 +102,7 @@ jobs:
         if: |
           inputs.run_shellcheck &&
           inputs.runs_on == 'ubuntu-latest' &&
-          matrix.ruby_version == '3.2'
+          matrix.ruby_version == '3.1'
         with:
           check_all_files_with_shebangs: "true"
 

--- a/.github/workflows/module_release_prep.yml
+++ b/.github/workflows/module_release_prep.yml
@@ -45,7 +45,7 @@ jobs:
       - name: "setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.1"
           bundler-cache: "true"
           bundler: 2.4.22
 


### PR DESCRIPTION
Puppet 7 is EOL. Therefore, we can remove the test infrastructure for it. This commit aims to clear up any testing/config infrastructure related to Puppet 7 and, by extension, Ruby 2.7. It also corrects ruby 3.2 expectations to be 3.1.
