### PR TITLE
ci(CAT-2275): add Twingate setup step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -75,8 +75,13 @@ jobs:
       BUNDLE_WITHOUT: release_prep
       PUPPET_GEM_VERSION: '~> 8.9'
       FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main'  # why is this set?
+      TWINGATE_PUBLIC_REPO_KEY: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 
     steps:
+      - name: "Install Twingate"
+        uses: "twingate/github-action@v1"
+        with:
+          service-key: ${{ env.TWINGATE_PUBLIC_REPO_KEY }}
 
       - name: "Checkout"
         uses: "actions/checkout@v4"


### PR DESCRIPTION
## Summary
Adds the Twingate installation step in `.github/workflows/...` using `twingate/github-action@v1`. The action uses the `${{ secrets.TWINGATE_KEY }}` to establish secure access to internal resources.

This enables the workflow to access protected infrastructure during CI runs.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
