### PR TITLE
(MAINT) Adding puppetcore var to module acceptance

### DIFF
--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -28,6 +28,7 @@ on:
 # - Set a valid PUPPET_FORGE_TOKEN secret on its repository.
 env:
   PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN }}
+  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN }}"
 
 jobs:
 


### PR DESCRIPTION
Module acceptance workflow requires the same env variables as the module ci workflow to run correctly. Adding it.