### PR TITLE
(ITHELP-123499) Update token to `PUPPET_FORGE_TOKEN_PUBLIC` if it exists

### DIFF
--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -36,8 +36,8 @@ on:
 env:
   PUPPET_GEM_VERSION: ${{ inputs.puppet_gem_version }}
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN }}
-  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN }}"
+  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
 
 jobs:
   spec:

--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -27,8 +27,8 @@ on:
 # ENABLE PUPPETCORE.  The calling workflow must:
 # - Set a valid PUPPET_FORGE_TOKEN secret on its repository.
 env:
-  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN }}
-  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN }}"
+  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
 
 jobs:
 

--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -29,8 +29,8 @@ on:
 # - Set a valid PUPPET_FORGE_TOKEN secret on its repository.
 # - Set ruby_version >= 3.1 to override this workflow's default 2.7; otherwise bundle install will fail.
 env:
-  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN }}
-  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN }}"
+  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
 
 jobs:
   setup_matrix:

--- a/.github/workflows/tooling_mend_ruby.yml
+++ b/.github/workflows/tooling_mend_ruby.yml
@@ -28,8 +28,8 @@ env:
   # ENABLE PUPPETCORE.  The calling workflow must:
   # - Set a valid PUPPET_FORGE_TOKEN secret on its repository.
   # - Set ruby_version >= 3.1 to override this workflow's default 2.7; otherwise bundle install will fail.
-  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN }}
-  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN }}"
+  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
 
 jobs:
   mend:


### PR DESCRIPTION
## Summary
Depending on the Module/Gem that is running against these workflows, the secret may be named either `PUPPET_FORGE_TOKEN` or `PUPPET_FORGE_TOKEN_PUBLIC`.
Update the code to allow either, with a preference for `PUPPET_FORGE_TOKEN`

## Checklist
- [x] Manually verified.
