### PR TITLE
(CAT-2409) Use metadata v3 and exclude 7th gen OSs

### DIFF
--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -10,7 +10,7 @@ on:
         default: "ubuntu-latest"
         type: "string"
       flags:
-        description: "Additional flags to pass to matrix_from_metadata_v2."
+        description: "Additional flags to pass to matrix_from_metadata_v3."
         required: false
         default: ''
         type: "string"
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Test Matrix
         id: get-matrix
         run: |
-          bundle exec matrix_from_metadata_v2 ${{ inputs.flags }}
+          bundle exec matrix_from_metadata_v3 ${{ inputs.flags }}
 
   acceptance:
     name: "Acceptance tests (${{matrix.platforms.label}}, ${{matrix.collection}})"

--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -10,7 +10,7 @@ on:
         default: "ubuntu-latest"
         type: "string"
       flags:
-        description: "Additional flags to pass to matrix_from_metadata_v2."
+        description: "Additional flags to pass to matrix_from_metadata_v3."
         required: false
         default: ''
         type: "string"
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Spec Test Matrix
         id: get-matrix
         run: |
-          bundle exec matrix_from_metadata_v2 ${{ inputs.flags }}
+          bundle exec matrix_from_metadata_v3 ${{ inputs.flags }}
 
   spec:
     name: "Spec tests (Puppet: ${{matrix.puppet_version}}, Ruby Ver: ${{matrix.ruby_version}})"


### PR DESCRIPTION
Following a recent team discussion and decisions, we decided its best to switch to the usage of matrix_from_metadata_v3 and exclude problematic 7th generation OSs from the acceptance tests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
