### PR TITLE
(CAT-2415) Update matrix_from_metadata to v3

### DIFF
--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -10,7 +10,7 @@ on:
         default: "ubuntu-latest"
         type: "string"
       flags:
-        description: "Additional flags to pass to matrix_from_metadata_v2."
+        description: "Additional flags to pass to matrix_from_metadata_v3."
         required: false
         default: ''
         type: "string"
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Test Matrix
         id: get-matrix
         run: |
-          bundle exec matrix_from_metadata_v2 ${{ inputs.flags }}
+          bundle exec matrix_from_metadata_v3 ${{ inputs.flags }}
 
   acceptance:
     name: "Acceptance tests (${{matrix.platforms.label}}, ${{matrix.collection}})"

--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -10,7 +10,7 @@ on:
         default: "ubuntu-latest"
         type: "string"
       flags:
-        description: "Additional flags to pass to matrix_from_metadata_v2."
+        description: "Additional flags to pass to matrix_from_metadata_v3."
         required: false
         default: ''
         type: "string"
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Spec Test Matrix
         id: get-matrix
         run: |
-          bundle exec matrix_from_metadata_v2 ${{ inputs.flags }}
+          bundle exec matrix_from_metadata_v3 ${{ inputs.flags }}
 
   spec:
     name: "Spec tests (Puppet: ${{matrix.puppet_version}}, Ruby Ver: ${{matrix.ruby_version}})"


### PR DESCRIPTION
## Summary
Updates the workflow to use `matrix_from_metadata_v3` in both the module acceptance and module CI workflows.

This change ensures the workflows are using the latest version of the matrix generation tool.

## Checklist
- [x] Manually verified.
