### PR TITLE
(CAT-2414) Stable fix for Almalinux 8

### DIFF
--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -7,7 +7,7 @@ on:
       runs_on:
         description: "The operating system used for the runner."
         required: false
-        default: "ubuntu-latest"
+        default: "ubuntu-22.04"
         type: "string"
       flags:
         description: "Additional flags to pass to matrix_from_metadata_v3."


### PR DESCRIPTION
Currently Almalinux 8 provisioning fails due to the platform having security policy issues with default ubuntu 24.04 Action images. This is a stable fix for this issue.
