### PR TITLE
Revert "(CAT-2414) Stable fix for Almalinux 8"

### DIFF
--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -7,7 +7,7 @@ on:
       runs_on:
         description: "The operating system used for the runner."
         required: false
-        default: "ubuntu-22.04"
+        default: "ubuntu-latest"
         type: "string"
       flags:
         description: "Additional flags to pass to matrix_from_metadata_v3."


### PR DESCRIPTION
Reverts puppetlabs/cat-github-actions#141

Reverting because ubuntu-24.04 does not like ubuntu-22.04.
