### PR TITLE
(CAT-2416) Address AlmaLinux 8 provisioning issue

### DIFF
--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -7,7 +7,6 @@ on:
       runs_on:
         description: "The operating system used for the runner."
         required: false
-        default: "ubuntu-latest"
         type: "string"
       flags:
         description: "Additional flags to pass to matrix_from_metadata_v3."
@@ -34,7 +33,7 @@ jobs:
 
   setup_matrix:
     name: "Setup Test Matrix"
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ubuntu-latest
     outputs:
       acceptance_matrix: ${{ steps.get-matrix.outputs.matrix }}
 
@@ -66,7 +65,7 @@ jobs:
   acceptance:
     name: "Acceptance tests (${{matrix.platforms.label}}, ${{matrix.collection}})"
     needs: "setup_matrix"
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ${{ inputs.runs_on || matrix.platforms.runner }}
     timeout-minutes: 180
     strategy:
       fail-fast: false


### PR DESCRIPTION
Currently Almalinux 8 provisioning fails due to the platform having security policy issues with default ubuntu 24.04 Action images. This is an update to allow a more flexible approach during provisioning so that Actions can consume the matrix.runner result of our scripts.

## Checklist
- [x] 🟢 Spec tests.
- [x] Manually verified.
