### PR TITLE
(CAT-2429) Exposes service URL as a workflow input

### DIFF
--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -14,6 +14,11 @@ on:
         required: false
         default: ''
         type: "string"
+      service_url:
+        description: "The service URL to target when provisioning from GCP."
+        required: false
+        default: 'https://facade-release-6f3kfepqcq-ew.a.run.app/v1/provision'
+        type: "string"
       run_shellcheck:
         description: "Run shellcheck on all bash files"
         required: false
@@ -31,6 +36,7 @@ on:
 env:
   PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
   BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
+  SERVICE_URL: ${{ inputs.service_url }}
 
 jobs:
   setup_matrix:


### PR DESCRIPTION
Allows users to specify the service URL when triggering the workflow.

This change introduces a new `service_url` input parameter to the workflow, enabling users to target different service endpoints, specifically when provisioning from GCP.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] Manually verified.
