### PR TITLE
(AT-2429) Configures service URL via workflow input

### DIFF
--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: ''
         type: "string"
+      service_url:
+        description: "The service URL to target when provisioning from GCP."
+        required: false
+        default: 'https://facade-release-6f3kfepqcq-ew.a.run.app/v1/provision'
+        type: "string"
       kernel_modules:
         description: "Volume map host kernel /lib/modules into docker container"
         default: true
@@ -28,6 +33,7 @@ on:
 env:
   PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
   BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
+  SERVICE_URL: ${{ inputs.service_url }}
 
 jobs:
 

--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -14,11 +14,6 @@ on:
         required: false
         default: ''
         type: "string"
-      service_url:
-        description: "The service URL to target when provisioning from GCP."
-        required: false
-        default: 'https://facade-release-6f3kfepqcq-ew.a.run.app/v1/provision'
-        type: "string"
       run_shellcheck:
         description: "Run shellcheck on all bash files"
         required: false
@@ -36,7 +31,6 @@ on:
 env:
   PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
   BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
-  SERVICE_URL: ${{ inputs.service_url }}
 
 jobs:
   setup_matrix:


### PR DESCRIPTION
Moves the service URL configuration to an input parameter for the `module_acceptance` workflow, enhancing flexibility. Had been mistakenly added to `module_ci` instead.

The service URL is now set as an environment variable using the provided input. This allows users to specify the target service URL when triggering the workflow.

## Checklist
- [x] 🟢 Spec tests.
- [x] Manually verified.
