### PR TITLE
(CAT-2561) Address module transient failures

### DIFF
--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -143,6 +143,8 @@ jobs:
           # Redact password
           FILE='spec/fixtures/litmus_inventory.yaml'
           sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
+          # Clean up resolv.conf on target Docker machines to avoid Azure DNS issues caused by Twingate actions
+          bundle exec bolt command run "sed '/^nameserver 168.63.129.16\$/d; /^search/d' /etc/resolv.conf > /tmp/resolv.conf && cat /tmp/resolv.conf > /etc/resolv.conf" --targets all --inventoryfile spec/fixtures/litmus_inventory.yaml
 
       - name: "Install Puppet agent"
         run: |


### PR DESCRIPTION
Module CI and nightlies have been struggling for some time with transient failures. The root cause of these was traced back to the Twingate step, which caused the Docker containers to inherit a resolv.conf file that container incompatible Azure DNS nameservers.

This commits adds a BOLT command to overwrite the configuration file and solve the issues.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
