### PR TITLE
(CAT-2624) Adjusting token logic

### DIFF
--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -36,7 +36,6 @@ jobs:
   setup_matrix:
     name: "Setup Test Matrix"
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.fork != true }}
     outputs:
       acceptance_matrix: ${{ steps.get-matrix.outputs.matrix }}
 

--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -156,11 +156,12 @@ jobs:
             DOCKER_RUN_OPTS=''
           fi
           bundle exec rake "litmus:provision[${{matrix.platforms.provider}},${{ matrix.platforms.image }},$DOCKER_RUN_OPTS]"
-          # Redact password
           FILE='spec/fixtures/litmus_inventory.yaml'
           sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
-          # Clean up resolv.conf on target Docker machines to avoid Azure DNS issues caused by Twingate actions
-          bundle exec bolt command run "sed '/^nameserver 168.63.129.16\$/d; /^search/d' /etc/resolv.conf > /tmp/resolv.conf && cat /tmp/resolv.conf > /etc/resolv.conf" --targets all --inventoryfile spec/fixtures/litmus_inventory.yaml
+          if [[ -n "$TWINGATE_PUBLIC_REPO_KEY" ]]; then
+            bundle exec bolt command run "sed '/^nameserver 168.63.129.16\$/d; /^search/d' /etc/resolv.conf > /tmp/resolv.conf && cat /tmp/resolv.conf > /etc/resolv.conf" --targets all --inventoryfile spec/fixtures/litmus_inventory.yaml
+          fi
+
 
       - name: "Install Puppet agent"
         run: |

--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -28,11 +28,7 @@ on:
         type: boolean
 
 
-# ENABLE PUPPETCORE.  The calling workflow must:
-# - Set a valid PUPPET_FORGE_TOKEN secret on its repository.
 env:
-  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
-  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
   SERVICE_URL: ${{ inputs.service_url }}
 
 jobs:
@@ -40,6 +36,7 @@ jobs:
   setup_matrix:
     name: "Setup Test Matrix"
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.fork != true }}
     outputs:
       acceptance_matrix: ${{ steps.get-matrix.outputs.matrix }}
 
@@ -50,6 +47,15 @@ jobs:
 
       - name: "Checkout"
         uses: "actions/checkout@v4"
+
+      - name: "Configure forge authentication"
+        env:
+          FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+        run: |
+          if [ -n "$FORGE_TOKEN" ]; then
+            echo "PUPPET_FORGE_TOKEN=$FORGE_TOKEN" >> $GITHUB_ENV
+            echo "BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM=forge-key:$FORGE_TOKEN" >> $GITHUB_ENV
+          fi
 
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
@@ -84,12 +90,23 @@ jobs:
       TWINGATE_PUBLIC_REPO_KEY: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 
     steps:
+      - name: "Configure forge authentication"
+        env:
+          FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+        run: |
+          if [ -n "$FORGE_TOKEN" ]; then
+            echo "PUPPET_FORGE_TOKEN=$FORGE_TOKEN" >> $GITHUB_ENV
+            echo "BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM=forge-key:$FORGE_TOKEN" >> $GITHUB_ENV
+          fi
+
       - name: "Install Twingate"
+        if: env.TWINGATE_PUBLIC_REPO_KEY != ''
         uses: "twingate/github-action@v1"
         with:
           service-key: ${{ env.TWINGATE_PUBLIC_REPO_KEY }}
 
       - name: Fix DNS
+        if: env.TWINGATE_PUBLIC_REPO_KEY != ''
         run: |
           echo "=== Remove Azure DNS from eth0 interface ==="
           sudo resolvectl dns eth0 ""

--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -30,13 +30,6 @@ on:
         default: ''
         type: "string"
 
-# ENABLE PUPPETCORE.  The calling workflow must:
-# - Set a valid PUPPET_FORGE_TOKEN secret on its repository.
-# - Set ruby_version >= 3.1 to override this workflow's default 2.7; otherwise bundle install will fail.
-env:
-  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
-  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
-
 jobs:
   setup_matrix:
     name: "Setup Test Matrix"
@@ -57,6 +50,15 @@ jobs:
       - name: "Install additional packages"
         if: ${{ inputs.additional_packages != '' }}
         run: sudo apt-get install -y ${{ inputs.additional_packages }}
+
+      - name: "Configure forge authentication"
+        env:
+          FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+        run: |
+          if [ -n "$FORGE_TOKEN" ]; then
+            echo "PUPPET_FORGE_TOKEN=$FORGE_TOKEN" >> $GITHUB_ENV
+            echo "BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM=forge-key:$FORGE_TOKEN" >> $GITHUB_ENV
+          fi
 
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
@@ -97,6 +99,15 @@ jobs:
       - name: "Install additional packages"
         if: ${{ inputs.additional_packages != '' }}
         run: sudo apt-get install -y ${{ inputs.additional_packages }}
+
+      - name: "Configure forge authentication"
+        env:
+          FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+        run: |
+          if [ -n "$FORGE_TOKEN" ]; then
+            echo "PUPPET_FORGE_TOKEN=$FORGE_TOKEN" >> $GITHUB_ENV
+            echo "BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM=forge-key:$FORGE_TOKEN" >> $GITHUB_ENV
+          fi
 
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"


### PR DESCRIPTION
Make forge auth and Twingate steps conditional for fork PR support

Move token setup out of top-level env into conditional shell steps so that empty strings are not passed into the Gemfile, where they can be interpreted as 'truthy'. Guard Twingate steps so repos without the secret skip them gracefully.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
