### PR TITLE
(maint) Update Checkout, Ruby

### DIFF
--- a/.github/actions/workflow-restarter-proxy/action.yml
+++ b/.github/actions/workflow-restarter-proxy/action.yml
@@ -26,7 +26,7 @@ runs:
 
     # checkout the repository because I want bundler to have access to my Gemfile
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # setup ruby including a bundle install of my Gemfile
     - name: Set up Ruby and install Octokit

--- a/.github/workflows/gem_acceptance.yml
+++ b/.github/workflows/gem_acceptance.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
 
       - name: "checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
 
       - name: "export environment"
         run: |

--- a/.github/workflows/gem_ci.yml
+++ b/.github/workflows/gem_ci.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: "checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
         with:
           fetch-depth: 1
       - name: "shellcheck"

--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
         with:
           ref: ${{ github.event.inputs.target }}
           clean: true

--- a/.github/workflows/gem_release_prep.yml
+++ b/.github/workflows/gem_release_prep.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
         with:
           ref: ${{ github.event.inputs.target }}
           clean: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
 
       - name: "Run yaml-lint"
         uses: "ibiqlik/action-yamllint@v3"

--- a/.github/workflows/mend_ruby.yml
+++ b/.github/workflows/mend_ruby.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: "checkout"
         if: success()
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
         with:
           fetch-depth: 1
 

--- a/.github/workflows/module_acceptance.yml
+++ b/.github/workflows/module_acceptance.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
 
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
 
       - name: "Configure forge authentication"
         env:
@@ -124,7 +124,7 @@ jobs:
           nslookup artifactory.delivery.puppetlabs.net
 
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
 
       - name: "Disable Apparmor"
         if: ${{ inputs.disable_apparmor }}

--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
 
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/module_release.yml
+++ b/.github/workflows/module_release.yml
@@ -20,7 +20,7 @@ jobs:
           ruby-version: "3.1"
 
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
         with:
           ref: "${{ github.ref }}"
           clean: true

--- a/.github/workflows/module_release_prep.yml
+++ b/.github/workflows/module_release_prep.yml
@@ -44,9 +44,8 @@ jobs:
       - name: "setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.3"
           bundler-cache: "true"
-          bundler: 2.4.22
 
       - name: "bundle environment"
         run: |

--- a/.github/workflows/module_release_prep.yml
+++ b/.github/workflows/module_release_prep.yml
@@ -12,7 +12,6 @@ on:
         required: true
         type: "string"
 
-
 jobs:
   release_prep:
     name: "Release prep"
@@ -24,7 +23,7 @@ jobs:
     steps:
 
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tooling_mend_ruby.yml
+++ b/.github/workflows/tooling_mend_ruby.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: "checkout"
         if: success()
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
         with:
           fetch-depth: 1
 

--- a/.github/workflows/workflow-restarter-test.yml
+++ b/.github/workflows/workflow-restarter-test.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       # (3) checkout this repository in order to "see" the following custom action
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Trigger reusable workflow
         uses: "puppetlabs/cat-github-actions/.github/actions/workflow-restarter-proxy@main"

--- a/.github/workflows/workflow-restarter.yml
+++ b/.github/workflows/workflow-restarter.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check retry count
         id: check-retry


### PR DESCRIPTION
## Summary
This PR updates the Checkout Action from the deprecated v4 to the current v6.

Additionally, this updates the Ruby version used in the release prep action from the EOL Ruby 3.1 to 3.3, and removes the Bundler pin originally put in place for troubleshooting.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
