### PR TITLE
(CAT-2581) Propagate PUPPET_FORGE_TOKEN to gem acceptance workflow

### DIFF
--- a/.github/workflows/gem_acceptance.yml
+++ b/.github/workflows/gem_acceptance.yml
@@ -25,6 +25,9 @@ on:
         default: "ubuntu-latest"
         type: "string"
 
+# ENABLE PUPPETCORE.  The calling workflow must:
+# - Set a valid PUPPET_FORGE_TOKEN secret on its repository.
+# - Set ruby_version >= 3.1 to override this workflow's default 2.7; otherwise bundle install will fail.
 jobs:
   acceptance:
     name: "acceptance"
@@ -32,6 +35,8 @@ jobs:
 
     env:
       PUPPET_GEM_VERSION: ${{ inputs.puppet_version }}
+      PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+      BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
 
     steps:
 


### PR DESCRIPTION
## Summary

Mirror the puppetcore wiring from gem_ci.yml to gem_acceptance.yml so that gem-based projects' acceptance lanes can authenticate to the puppetcore private gem source (https://rubygems-puppetcore.puppet.com) the same way their spec lanes already do.

Without this, the acceptance job sees no PUPPET_FORGE_TOKEN env var, so when it renders a fresh module via `pdk new module` (or any code that consumes the pdk-templates Gemfile.erb), the rendered Gemfile's `gemsource_puppetcore` switch stays on rubygems.org, and any bolt / puppet / facter gem published only to puppetcore (e.g. bolt 5.x) is unreachable. On Ruby 4 specifically this causes bundle resolution to fail because the only rubygems.org bolt version (4.0.0) pins `r10k < 5`, which cascades through puppet_forge < 6 to a faraday-follow_redirects 0.3.x gemspec constraint that excludes Ruby >= 4. Discovered while landing Ruby 4 support on pdk (CAT-2581 / pdk-private PR #48).

Add two job-scoped env vars to gem_acceptance.yml (identical to the ones already present at workflow scope in gem_ci.yml):

* `PUPPET_FORGE_TOKEN` from secrets.PUPPET_FORGE_TOKEN with a fallback to secrets.PUPPET_FORGE_TOKEN_PUBLIC. Setting this triggers the `gemsource_puppetcore` switch in pdk-templates' rendered Gemfile.

* `BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM` set to "forge-key:<TOKEN>". This is Bundler's canonical env-var form of `bundle config rubygems-puppetcore.puppet.com forge-key:<TOKEN>` and authenticates the bundler download from puppetcore.

Calling workflows must set PUPPET_FORGE_TOKEN as a repo / org secret (secrets.PUPPET_FORGE_TOKEN_PUBLIC is the fork-friendly fallback) and pass `secrets: inherit`, the same prerequisites as gem_ci.yml.

## Checklist
- [x] Manually verified.
