### PR TITLE
(maint) Authenticate to puppetcore in gem release workflows

### DIFF
--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -12,6 +12,13 @@ on:
         default: "main"
         type: "string"
 
+# ENABLE PUPPETCORE. The calling workflow must set `secrets: inherit` and a valid
+# PUPPET_FORGE_TOKEN secret so `bundle install` can authenticate to the
+# rubygems-puppetcore.puppet.com source when the Gemfile uses it.
+env:
+  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
+
 jobs:
   release:
     name: "Release"

--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -12,9 +12,6 @@ on:
         default: "main"
         type: "string"
 
-# ENABLE PUPPETCORE. The calling workflow must set `secrets: inherit` and a valid
-# PUPPET_FORGE_TOKEN secret so `bundle install` can authenticate to the
-# rubygems-puppetcore.puppet.com source when the Gemfile uses it.
 env:
   PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
   BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"

--- a/.github/workflows/gem_release_prep.yml
+++ b/.github/workflows/gem_release_prep.yml
@@ -17,9 +17,6 @@ on:
         required: true
         type: "string"
 
-# ENABLE PUPPETCORE. The calling workflow must set `secrets: inherit` and a valid
-# PUPPET_FORGE_TOKEN secret so `bundle install` can authenticate to the
-# rubygems-puppetcore.puppet.com source when the Gemfile uses it.
 env:
   PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
   BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"

--- a/.github/workflows/gem_release_prep.yml
+++ b/.github/workflows/gem_release_prep.yml
@@ -17,6 +17,13 @@ on:
         required: true
         type: "string"
 
+# ENABLE PUPPETCORE. The calling workflow must set `secrets: inherit` and a valid
+# PUPPET_FORGE_TOKEN secret so `bundle install` can authenticate to the
+# rubygems-puppetcore.puppet.com source when the Gemfile uses it.
+env:
+  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
+
 jobs:
   release_prep:
     name: "Release Prep"


### PR DESCRIPTION
## Problem

`gem_release_prep.yml` and `gem_release.yml` run `bundle install` (via `ruby/setup-ruby@v1` with `bundler-cache: true`) but, unlike `gem_ci.yml`, never set the puppetcore credential.

As consuming gems adopt the Ruby 4 / Puppet 9 migration — which adds the **authenticated** `rubygems-puppetcore.puppet.com` source to their `Gemfile` — release prep and release start failing at the `setup ruby` step:

```
Authentication is required for rubygems-puppetcore.puppet.com.
Please supply credentials for this source. ...
##[error]The process '.../bundle' failed with exit code 17
```

First hit by `puppet_litmus`: its CAT-2588 PR (puppetcore source) merged to `main` on 2026-06-16, after the last release; the next Release Prep run then failed. `gem_ci.yml` is unaffected because it already exports the token. This will affect **every** puppetlabs gem repo as it picks up the puppetcore Gemfile change.

## Fix

Add the same workflow-level `env:` that `gem_ci.yml` already uses to both release workflows, so the bundler install authenticates from the inherited `PUPPET_FORGE_TOKEN` secret:

```yaml
env:
  PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
  BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
```

Callers already pass `secrets: inherit`, so no downstream change is required. Repos whose Gemfile doesn't use the puppetcore source are unaffected (the var is simply unused).

## Notes

- Mirrors the existing pattern and forge-auth convention documented in `gem_ci.yml` / `CLAUDE.md`.
- No input/interface changes, so no downstream caller updates needed.